### PR TITLE
Documentation Updates

### DIFF
--- a/docs/UsersGuide/source/faq.rst
+++ b/docs/UsersGuide/source/faq.rst
@@ -5,20 +5,23 @@ FAQ
 ===
 
 How can I set required environment variables?
-=====================================================================
+=============================================
+The best practice to set environment variables (``UFS_SCRATCH`` and ``UFS_INPUT``)
+and source the NCEPLIBS provided shell script (``setenv_nceplibs.sh|.csh``) is
+to put them into the ``.bashrc`` (Bash shell) or ``.tcshrc`` (Tcsh shell) files.
+These files are executed when a user opens a new shell or logs in to the server
+(including compute nodes) so that their environment is set correctly.
 
-The best practice to set environment variables (``UFS_SCRATCH`` and ``UFS_INPUT``) and source NCEPLIBS provided shell script (``setenv_nceplibs.sh|.csh``) is
- to put them into the ``.bashrc`` (Bash shell) or ``.tcshrc`` (Tcsh shell) files. These files are executed when user opens a new shell or logins to the server
- (incl. compute nodes) so that their environment is set correctly.
+**BASH (edit ~/.bashrc):**
 
-**BASH (edit ~/.bashrc): **
 .. code-block:: console
 
     export UFS_INPUT=/path/to/inputs
     export UFS_SCRATCH=/path/to/outputs
     source /path/to/nceplibs/bin/setenv_nceplibs.sh 
 
-**BASH (edit ~/.tcshrc): **
+**BASH (edit ~/.tcshrc):**
+
 .. code-block:: console
 
     setenv UFS_INPUT /path/to/inputs
@@ -32,7 +35,7 @@ The best practice to set environment variables (``UFS_SCRATCH`` and ``UFS_INPUT`
 How can I see/check the steps in my workflow?
 =============================================
 
-A good way to see what _case.submit_ will do, is to use **preview_run** command,
+A good way to see what ``case.submit`` will do, is to use the ``preview_run`` command,
 which will output the environment for your run along with the batch submit and mpirun commands.
 The following is example output for the UFS Medium-Range Weather workflow:
 
@@ -44,17 +47,18 @@ The following is example output for the UFS Medium-Range Weather workflow:
 How can I run an individual task in the existing workflow?
 ==========================================================
 
-The CIME-CCS allows you to run the specific task in the workflow by supplying the **--only-job** parameter to the **case.submit** command.
+The CIME-CCS allows you to run the specific task in the workflow by supplying the ``--only-job``
+parameter to the ``case.submit`` command.
 
-Following the example to run only the preprocessing utility **chgres_cube**
+The following example will run only the preprocessing utility ``chgres_cube``:
 
 .. code-block:: console
 
     cd $CASEROOT
     ./case.submit --only-job case.chgres
 
-This will create the initial conditions for the model simulation using the raw input files are provided by NOAA Operational Model
-Archive and Distribution System (NOMADS).
+This will create the initial conditions for the model simulation using the raw input files that are
+provided by NOAA Operational Model Archive and Distribution System (NOMADS).
 
 To run the simulation:
 
@@ -63,7 +67,7 @@ To run the simulation:
     cd $CASEROOT
     ./case.submit --only-job case.run
 
-If user wants to define the first job submitted in a workflow, the **--job** parameter can be pass to the **case.submit** command.
+If the user wants to define the first job submitted in a workflow, the ``--job`` parameter can be passed to the ``case.submit`` command.
 
 .. code-block:: console
 
@@ -75,16 +79,16 @@ In this case, two dependent jobs will be submitted: model simulation and post-pr
 How can I change wall clock time/queue for specific task in the workflow?
 ================================================================================
 
-These can be done by using ``xmlchange`` command.
+These can be done by using the ``xmlchange`` command.
 
-For example, following can be used to set job wall clock time to 10 minutes for **chgres_cube**
+For example, the following command can be used to set the job wall clock time to 10 minutes for ``chgres_cube``
 
 .. code-block:: console
 
     cd $CASEROOT
     ./xmlchange JOB_WALLCLOCK_TIME=00:10:00 --subgroup case.chgres
 
-The following command will change the job queue as **bigmem** for **chgres_cube**
+The following command will change the job queue to ``bigmem`` for ``chgres_cube``:
 
 .. code-block:: console
 
@@ -93,15 +97,17 @@ The following command will change the job queue as **bigmem** for **chgres_cube*
 
 .. note::
 
-    without **--subgroup** option, the **xmlchange** command changes the job wall clock time for the simulation itself (**case.run**).
+    Without the ``--subgroup`` option, the ``xmlchange`` command changes the job wall clock time for the
+    simulation itself (``case.run``).
 
 How can I change the project account that will be used to submit jobs?
 ======================================================================
 
 There are two ways to change project account that is used to submit job:
 
-* Set **PROJECT** environment variable before creating case
-* Use ``xmlchange`` command to change project account. The following command can be used to change project account for **chgres_cube** task (please replace PROJECT ID with an appropriate project number).
+* Set ``PROJECT`` environment variable before creating case
+* Use the ``xmlchange`` command to change the project account. The following command can be used to change the project
+  account for the ``chgres_cube`` task (please replace PROJECT ID with an appropriate project number).
 
 .. code-block:: console
 
@@ -127,23 +133,23 @@ and to change the default processor layout:
     cd $CASEROOT
     ./xmlchange NTASKS_ATM=150
 
-This will set the total number of processor to 150 but the model configuration files (**model_configure** and **input.nml**) need to be changed to be
-consistent with the total number of processor set by ``xmlchange`` command.
+This will set the total number of processor to 150, but the model configuration files (``model_configure`` and ``input.nml``) must be changed to be
+consistent with the total number of processors set by the ``xmlchange`` command.
 
-In this case, following namelist options need to be modified accordingly:
+In this case, the following namelist options need to be modified accordingly:
 
 - **layout**: Processor layout on each tile.
 - **ntiles**: Number of tiles on the domain. For the cubed sphere, this should be 6, one tile for each face of the cubed sphere.
 - **write_groups**: Number of group for I/O tasks.
 - **write_tasks_per_group**: Number of I/O tasks for each group.
 
-The number of tasks assigned to a domain for UFS Medium-Range Weather Model needs must equal to
+The number of tasks assigned to a domain for UFS Medium-Range Weather Model must be equal to:
 
 .. math::
 
     NTASKS\_ATM = layout_x * layout_y * ntiles + write\_tasks\_per\_group * write\_groups
 
-To have consistent model configuration with **NTASKS_ATM** defined above. ``user_nl_ufsatm`` can be changed as following
+to have consistent model configuration with **NTASKS_ATM** defined above. ``user_nl_ufsatm`` can be changed as following:
 
 .. code-block:: console
 
@@ -158,12 +164,14 @@ To have consistent model configuration with **NTASKS_ATM** defined above. ``user
 
 .. note::
 
-    The model resolution also need to be divided evenly with the layout pair. For the given configuration (C96 resolution), :math:`96/3 = 32` and :math:`96/8 = 12`
+    The model resolution also needs to divide evenly with the layout pair. For the given configuration (C96 resolution), :math:`96/3 = 32` and :math:`96/8 = 12`.
 
 How do I change the number of OPENMP threads?
 =============================================
 
-User might need to change the number of threads to reduce memory consumption for each compute node expecially for high-resolution cases, which is already set by CIME-CSS for C768. This can be done by using following command:
+The user may need to change the number of threads to reduce memory consumption for each compute node. This is
+especially true for high-resolution cases, which is already set by CIME-CSS for C768. This can be done
+using the following command:
 
 .. code-block:: console
 
@@ -173,13 +181,13 @@ User might need to change the number of threads to reduce memory consumption for
 
 .. note::
 
-    The model needs to be build again by threading support. Setting **NTHRDS_ATM** does not require to make chnages in the model
-    configuration files. The job submission scripts handle it automatically and submit jobs using more compute node.
+    The model needs to be built again if threading is changed. Setting **NTHRDS_ATM** does not require changes in the model
+    configuration files. The job submission scripts handle it automatically and submit jobs using more compute nodes.
 
 How do I restart the model?
 ===========================
 
-To restart the model ``xmlchange`` command can be used:
+To restart the model the ``xmlchange`` command can be used:
 
 .. code-block:: console
 
@@ -187,13 +195,13 @@ To restart the model ``xmlchange`` command can be used:
     ./xmlchange CONTINUE_RUN=TRUE
     ./case.submit
 
-In this case, CIME-CCS makes the required changes the model namelist files (``model_configure`` and ``input.nml``) and also copies the files from **RESTART** to **INPUT** directory.
+In this case, CIME-CCS makes the required changes to the model namelist files (``model_configure`` and ``input.nml``) and also copies the files from the ``RESTART`` to the ``INPUT`` directory.
 
 .. note::
 
-    If there are restarts files belongs to multiple time snapshots (i.e. 20190829.060000., 20190829.120000. prefixes if it is written in every 6-hours), CIME-CCS gets the latest one (the files with **20190829.120000.** prefix) automatically.
+    If there are restart files belonging to multiple time snapshots (i.e. with 20190829.060000., 20190829.120000. prefixes if it is written every 6-hours), CIME-CCS gets the latest one (the files with ``20190829.120000.`` prefix) automatically.
 
-The restart interval can be also changed to 6 hourly interval as following:
+The restart interval can also be changed to a 6 hourly interval as following:
 
 .. code-block:: console
 
@@ -203,9 +211,9 @@ The restart interval can be also changed to 6 hourly interval as following:
 
 .. note::
 
-    The default value of **restart_interval** namelist option is zero (0) and the model writes single restart file at the end of the simulation.
+    The default value of the **restart_interval** namelist option is zero (0), and the model writes a single restart file at the end of the simulation.
 
-The following example demonstrates the 48 hours model simulation split into an initial 24-hour simulation with cold start plus an additional 24-hour simulation with warm start.
+The following example demonstrates the 48 hour model simulation split into an initial 24-hour simulation with a cold start plus an additional 24-hour simulation with warm start.
 
 The initial 24 hours simulation:
 
@@ -226,11 +234,11 @@ and restart the model for 24 hours simulation:
 
 .. note::
 
-    The restart run length can be changed using ``xmlchange`` command by setting **STOP_N** and **STOP_OPTION**.
+    The restart run length can be changed using the ``xmlchange`` command and setting ``STOP_N`` and ``STOP_OPTION``.
 
 How do I change a namelist option for chgres_cube or the model?
-======================================================================
-To set a model namelist options in CIME, edit file ``user_nl_ufsatm`` in
+===============================================================
+To set model namelist options in CIME, edit the file ``user_nl_ufsatm`` in
 the case and add the change(s) as name-value pairs. For example:
 
 .. code-block:: console
@@ -270,19 +278,19 @@ the case and add the change(s) as name-value pairs. For example:
     !----------------------------------------------------------------------------------
     do_skeb = T
 
-Then run ``./case.submit`` this will update the namelist and submit the job.
+Then run ``./case.submit``. This will update the namelist and submit the job.
 
 If you want to review what you have done before you submit the case, you can
 run ``./preview_namelists`` and then examine the namelist(s) in the run directory
-or the case subdirectory CaseDocs/.
+or the case subdirectory ``CaseDocs/``.
 
 Some variables are tied to xml in the case and can only be changed via the
-``xmlchange`` command. Attempting to change them by editing file
-``user_nl_ufsatm`` skeb generate an error.
+``xmlchange`` command. Attempting to change them by editing the file
+``user_nl_ufsatm`` may generate an error.
 
 .. warning::
 
-    The ``user_nl_ufsatm`` file is also used to control namelist options for chgres_cube and NCEP-Post and different namelist groups in model namelist and pre-, post-processing tools could have same namelist variable. In this case, just using namelist variable name causes failure in automated namelist generation. The following is the list of namelist variables that needs to be used along with their group name.
+    The ``user_nl_ufsatm`` file is also used to control namelist options for chgres_cube and NCEP-Post. Different namelist groups in the model namelist and the pre-, post-processing tools could have the same namelist variable. In this case, just using the namelist variable causes failures in the automated namelist generation. The following is the list of namelist variables that needs to be used along with their group name.
 
     - alpha@nam_physics_nml
     - alpha@test_case_nml
@@ -302,7 +310,7 @@ Some variables are tied to xml in the case and can only be changed via the
     - regional@fv_core_nml
 
 Can I customize the UPP output?
-================================================================
+===============================
 
 At this time the CIME workflow does not support the customization of the
 variables or levels output by UPP.
@@ -310,11 +318,11 @@ variables or levels output by UPP.
 How do I find out which platforms are preconfigured for the MR Weather App?
 ===========================================================================
 
-Preconfigured  machines are platforms that have machine specific files and settings scripts and that should
-run the  UFS Medium-Range (MR) Weather Application **out-of-the-box** (other than potentially needing to download input files).
-Preconfigured are usually listed by their common site-specific name.
+Preconfigured machines are platforms that have machine specific files and settings scripts and should
+run the UFS Medium-Range (MR) Weather Application **out-of-the-box** (other than potentially needing to download input files).
+Preconfigured platforms are usually listed by their common site-specific name.
 
-To see the list of preconfigured  out of the box platforms, issue the following commands:
+To see the list of preconfigured, out of the box platforms, issue the following commands:
 
 .. code-block:: console
 
@@ -355,7 +363,7 @@ needed to initialize the operational NSST parameterization.
 How can I change number of task used by chgres_cube or UPP (NCEP-Post)?
 =======================================================================
 
-By default, CIME-CCS automatically sets number of tasks used by chgres_cube and NCEP-Post (:term:`UPP`) based on the
+By default, CIME-CCS automatically sets number of tasks used by ``chgres_cube`` and NCEP-Post (:term:`UPP`) based on the
 resolution of the created case using following logic:
 
 - **chgres_cube**
@@ -378,22 +386,25 @@ The number of tasks will increase along with the increased horizontal resolution
 memory consumption of the pre-processing tool and **tasks_per_node** is defined for the each platform
 using **MAX_MPITASKS_PER_NODE** element (i.e. 36 for NCAR Cheyenne and 48 for TACC Stampede2).
 
-To change the values set automatically by CIME-CSS, ``xmlchange`` command can be used:
+To change the values set automatically by CIME-CSS, the ``xmlchange`` command can be used:
 
 .. code-block:: console
 
     cd $CASEROOT
     ./xmlchange task_count=72 --subgroup case.chgres
 
-This command will change the number of task used by chgres_cube to 72. If user wants to change number of
-task for NCEP-Post, the subgroup option need to set to ``case.gfs_post``.
+This command will change the number of tasks used by chgres_cube to 72. If the user wants to change the number of
+task for NCEP-Post, the subgroup option needs to set to ``case.gfs_post``.
 
 How to change the filenames for input to chgres_cube?
 =====================================================
 
-By default, CIME-CSS uses `pre-defined convention <https://ufs-mrweather-app.readthedocs.io/en/latest/inputs_outputs.html>`_ to define folder and file names for raw input to chgres_cube. In this case, 0.5-degree data in GRIB2 format is used from `NCDC - Global Forecast System <https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs>`_.
+By default, CIME-CSS uses `pre-defined convention <https://ufs-mrweather-app.readthedocs.io/en/latest/inputs_outputs.html>`_ to define directory and file names for raw input to ``chgres_cube``. In this case, 0.5-degree data in GRIB2 format is used from `NCDC - Global Forecast System <https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs>`_.
 
-In case of using 1.0-degree GRIB2 format data (with gfs_3_YYYYMMDD_00HH_000.grb2 naming convention), user need to download file manuallay and placed under ``$DIN_LOC_IC/YYYYMM/YYYYMMDD```. Then, ``grib2_file_input_grid`` chgres_cube namelist variable need to be modified by editing ``user_nl_ufsatm`` file (resides in the ``$CASEROOT``) as following (for Dorian case):
+In the case of using 1.0-degree GRIB2 format data (with ``gfs_3_YYYYMMDD_00HH_000.grb2`` naming convention),
+the user needs to download the file manually and place it under ``$DIN_LOC_IC/YYYYMM/YYYYMMDD```. Then, the
+``grib2_file_input_grid`` ``chgres_cube`` namelist variable needs to be modified by editing the
+``user_nl_ufsatm`` file, which resides in the ``$CASEROOT`` directory. The following example is for the Dorian case:
 
 .. code-block:: console
 
@@ -434,8 +445,6 @@ In case of using 1.0-degree GRIB2 format data (with gfs_3_YYYYMMDD_00HH_000.grb2
 
 .. note::
 
-    Please be aware that tests were not done with the AVN, MRF or analysis data.
-
-.. note::
-
-    Please be aware that the date used in the directory naming must match with the data used in file name.
+    Please be aware that:
+      - Tests were not done with the AVN, MRF or analysis data.
+      - The date used in the directory naming must match the date used in file name.

--- a/docs/UsersGuide/source/introduction.rst
+++ b/docs/UsersGuide/source/introduction.rst
@@ -168,7 +168,7 @@ ways to choose the grid resolution, as well as to change namelist options,
 such as history file frequency. It also allows for configuration of other
 elements of the workflow; for example, whether to run some or all of the
 pre-processing, forecast model, and post-processing steps. The CIME-CCS builds
-the forecast model and the workflow itself, but not the NCEP Libraries or the
+the forecast model and the workflow itself, but not the :term:`NCEP` Libraries or the
 pre- and post-processing tools.
 
 `CIME`_ supports a set of tests for the UFS MR Weather App, including the Smoke

--- a/docs/UsersGuide/source/quickstart.rst
+++ b/docs/UsersGuide/source/quickstart.rst
@@ -10,13 +10,15 @@ The following quick start guide is applicable to versions of the `UFS Medium-Ran
 `here <https://github.com/ufs-community/ufs/wiki/Supported-Platforms-and-Compilers>`_.
 
 
-The workflow for building and running the App is built on the :term:`CIME`
+The workflow for building and running the App is built on the CIME
 (Common Infrastructure for Modeling Earth) framework.  Please refer to
 the `CIME Porting Documentation <http://esmci.github.io/cime/users_guide/porting-cime.html>`_ if CIME
 has not yet been ported to the target machine.
 
-If you are new to :term:`CIME`, please consider reading the
-`CIME Case Control System Part 1: Basic Usage <https://esmci.github.io/cime/users_guide/index.html#case-control-system-part-1-basic-usage>`_ first.
+If you are new to CIME, please consider reading the `CIME Case Control System Part 1: Basic Usage
+<https://esmci.github.io/cime/users_guide/index.html#case-control-system-part-1-basic-usage>`_ 
+*after downloading the code*.  The CIME Users Guide will be easier to follow after the
+directory structure has been created by the `git clone` command.
 
 This is the procedure for quickly setting up and running a case of UFS MR Weather App.
 
@@ -51,13 +53,13 @@ code:
     When cloning the ufs-mrweather-app repository on Hera, the connection to github may time out.  In this
     case, resubmit the ``git clone`` command.
 
-To checkout UFS MR Weather Model components, including CIME, run the **checkout_externals** script from /path/to/my_ufs_sandbox.
+To checkout UFS MR Weather Model components, including CIME, run the ``checkout_externals`` script from /path/to/my_ufs_sandbox.
 
 .. code-block:: console
 
     ./manage_externals/checkout_externals
 
-The **checkout_externals** script will read the configuration file called ``Externals.cfg`` and
+The ``checkout_externals`` script will read the configuration file called ``Externals.cfg`` and
 will download model and CIME into /path/to/my_ufs_sandbox.
 
 To see more details regarding the checkout_externals script from the command line, type:
@@ -244,14 +246,14 @@ Two environment variables need to be set prior to running the CIME workflow:
 
 The following settings are recommended on the pre-configured platforms:
 
-.. table::  Centralized list of documentation
+.. table::  Path settings for pre-configured platforms.
 
    +---------------------+-----------------------------------------+-------------------------------+
    | **Platform**        | **$UFS_INPUT**                          |   **$UFS_SCRATCH**            |
    +=====================+=========================================+===============================+
    | NCAR cheyenne       | $CESMDATAROOT                           | /glade/scratch/$USER          |
    +---------------------+-----------------------------------------+-------------------------------+
-   | NOAA hera           | <my-project-dir>/$USER                  | <my-project-dir>/$USER        |
+   | NOAA hera           | /scratch1/NCEPDEV/stmp2/CIME_UFS        | <my-project-dir>/$USER        |
    +---------------------+-----------------------------------------+-------------------------------+
 
 
@@ -276,20 +278,20 @@ Create a case
 
 The `create_newcase`_ command creates a case directory containing the scripts and XML
 files to configure a case (see below) for the requested resolution, component set, and
-machine. **create_newcase** has three required arguments: ``--case``, ``--compset`` and
+machine. ``create_newcase`` has three required arguments: ``--case``, ``--compset`` and
 ``--res``.   The ``workflow`` argument is optional, to select alternate workflow components (see below).
-(invoke **create_newcase --help** for help).
+(invoke ``create_newcase --help`` for help).
 
 On machines where a project or account code is needed, you
-must either specify the ``--project $PROJECT`` argument in the **create_newcase** command, or set the
+must either specify the ``--project $PROJECT`` argument in the ``create_newcase`` command, or set the
 ``$PROJECT`` variable in your shell environment.  If this argument is not set, the error message
 ``ERROR: PROJECT_REQUIRED`` will be reported.
 
 If running on a supported machine, that machine will
 normally be recognized automatically and therefore it is *not* required
-to specify the ``--machine`` argument to **create_newcase**.
+to specify the ``--machine`` argument to ``create_newcase``.
 
-Invoke **create_newcase** as follows from the ``cime/scripts`` directory:
+Invoke ``create_newcase`` as follows from the ``cime/scripts`` directory:
 
 .. code-block:: console
 
@@ -300,7 +302,7 @@ where:
 
 - ``CASENAME`` defines the name of your case (stored in the ``$CASE`` XML variable). This
   is a very important piece of metadata that will be used in filenames, internal metadata
-  and directory paths. **create_newcase** will create the *case directory* with the same
+  and directory paths. ``create_newcase`` will create the *case directory* with the same
   name as the ``CASENAME``. If ``CASENAME`` is simply a name (not a path), the case
   directory is created in the ``cime/scripts`` directory where you executed create_newcase.
   If ``CASENAME`` is a relative or absolute path, the case directory is created there and the name of the
@@ -334,24 +336,29 @@ along with namelist ``user_nl_xxx`` files, where xxx denotes the set of componen
 for the given case configuration such as ``ufsatm`` and ``cpl``.
 Selected namelist entries can be customized by editing ``user_nl_xxx``, see FAQ.
 
-cd to the case directory. Following the example from above:
+cd to the case directory ``$UFS_SCRATCH/ufs-mrweather-app-workflow.c96`` as shown above:
 
 .. code-block:: console
 
     cd /glade/scratch/$USER/cases/ufs-mrweather-app-workflow.c96
 
-Before invoking **case.setup**, you could modify the ``env_mach_pes.xml`` file in the case directory
+Before invoking ``case.setup``, you could modify the ``env_mach_pes.xml`` file in the case directory
 using the `xmlchange`_ command as needed for the experiment (optional). (Note: To edit any of
-the env xml files, use the `xmlchange`_ command. **xmlchange --help** can be used for help.)
+the env xml files, use the `xmlchange`_ command. ``xmlchange --help`` can be used for help.)
 
 Please also be aware that you need to provide consistent ``layout``, ``write_tasks_per_group`` and
 ``write_groups`` namelist options to the model when total number of PEs are changed.
 
-Invoke the **case.setup** command.
+Invoke the ``case.setup`` command.
 
 .. code-block:: console
 
     ./case.setup
+
+.. note::
+
+   The CIME commands ``./xmlquery``, ``./case.setup``, ``./case.build``, ``./case.submit`` reside in the
+   directory specified by ``--case`` when the ``./create_newcase`` is run.
 
 Build the executable using the case.build command
 =================================================
@@ -430,7 +437,7 @@ now are:
    - ``RUN_STARTDATE`` is the start date and need to be given in YYYY-MM-DD format such as 2020-01-15
    - ``START_TOD`` is the time of day in seconds such as 12 UTC need to be given as 43200 seconds.
 
-Submit the job to the batch queue using the **case.submit** command.
+Submit the job to the batch queue using the ``case.submit`` command.
 
 .. code-block:: console
 
@@ -438,13 +445,14 @@ Submit the job to the batch queue using the **case.submit** command.
 
 Based on the selected workflow (``ufs-mrweather`` or ``ufs-mrweather_wo_post``), the ``case.submit``
 command submits a chain of jobs that their dependency is automatically set. For example, ``ufs-mrweather``
-workflow submit a job array with three seperate job that will run in an order: pre-processing, simulation
-and post-processing.
+workflow submits a job array with three seperate jobs that will run in an order: pre-processing, simulation
+and post-processing.  The first ten characters of the job names will be ``chgres.ufs``, ``run.ufs-mr``, and
+``gfs_post.u``, respectively.
 
 When the jobs are complete, most output will *NOT* be written under the case directory, but
 instead under some other directories (on NCAR's cheyenne machine, these other directories
 will be in ``/glade/scratch/$USER``). Review the following directories and files, whose
-locations can be found with **xmlquery** (note: **xmlquery** can be run with a list of
+locations can be found with ``xmlquery`` (note: ``xmlquery`` can be run with a list of
 comma separated names and no spaces):
 
 .. code-block:: console

--- a/docs/UsersGuide/source/repos_and_directories.rst
+++ b/docs/UsersGuide/source/repos_and_directories.rst
@@ -70,8 +70,8 @@ in configuration file ``Externals.cfg``, which is in the top directory where the
 has been cloned. A listing of the directory structure is shown :ref:`here <top_level_dir_structure>`.
 
 The directory structures for the standalone UFS Weather Model and the UFS Weather Model included with
-the UFS MR Weather App are equal in that they contain subdirectories for FMS, FV3, NEMS and
-stochastic_physics. However, in the UFS Weather App, subdirectories are located under ``src/model``.
+the UFS MR Weather App are equal in that they contain subdirectories for :term:`FMS`, :term:`FV3`, :term:`NEMS`
+and stochastic_physics. However, in the UFS Weather App, subdirectories are located under ``src/model``.
 The UFS MR Weather App also includes directories for CIME, such as the ``src/model/FV3/cime`` and
 ``src/model/NEMS/cime`` directories.
 


### PR DESCRIPTION
- Glossary does not have unused terms
- UFS_INPUT is set to proper directory for Hera in quickstart
- Suggest cloning the code before reading CIME documentation in quickstart
- Made a note on location of CIME commands ./xmlquery, etc.
- Specified job names in quickstart that correspont to jobs submitted.
- Reviewed FAQ chapter and made modifications, mostly wording and denoting commands and variables

html and pdf builds are successful