### PR TITLE
User guide update

### DIFF
--- a/docs/UsersGuide/source/faq.rst
+++ b/docs/UsersGuide/source/faq.rst
@@ -6,11 +6,13 @@ FAQ
 
 How can I set required environment variables?
 =============================================
-The best practice to set environment variables (``UFS_SCRATCH`` and ``UFS_INPUT``)
-and source the NCEPLIBS provided shell script (``setenv_nceplibs.sh|.csh``) is
+The best practice to set environment variables (``UFS_SCRATCH``, ``UFS_INPUT``,
+``UFS_DRIVER``, ``CIME_MODEL``, and ``PROJECT``) is
 to put them into the ``.bashrc`` (Bash shell) or ``.tcshrc`` (Tcsh shell) files.
 These files are executed when a user opens a new shell or logs in to the server
-(including compute nodes) so that their environment is set correctly.
+(including compute nodes) so that their environment is set correctly. In platforms
+that are not preconfigured, the NCEPLIBS-provided shell script (``setenv_nceplibs.sh|.csh``)
+should be sourced in the same way.
 
 **BASH (edit ~/.bashrc):**
 
@@ -18,6 +20,9 @@ These files are executed when a user opens a new shell or logs in to the server
 
     export UFS_INPUT=/path/to/inputs
     export UFS_SCRATCH=/path/to/outputs
+    export PROJECT=your_compute_project
+    export UFS_DRIVER=nems
+    export CIME_MODEL=ufs
     source /path/to/nceplibs/bin/setenv_nceplibs.sh
 
 **BASH (edit ~/.tcshrc):**
@@ -26,11 +31,14 @@ These files are executed when a user opens a new shell or logs in to the server
 
     setenv UFS_INPUT /path/to/inputs
     setenv UFS_SCRATCH /path/to/outputs
+    setenv PROJECT your_compute_project
+    setenv UFS_DRIVER nems
+    setenv CIME_MODEL ufs
     source /path/to/nceplibs/bin/setenv_nceplibs.csh
 
 .. note::
 
-    The user might need to create ``~/.bashrc`` or ``~/.tcshrc`` file.
+    The user might need to create the ``~/.bashrc`` or ``~/.tcshrc`` file.
 
 How can I see/check the steps in my workflow?
 =============================================
@@ -326,7 +334,7 @@ The parameters that need to be changed via ``xmlchange`` are defined in ``nameli
     <entry id="nhours_fcst" modify_via_xml="STOP_N">
     <entry id="restart_interval" modify_via_xml="REST_N”>
 
-The changes are required to ensure consistency between the model configuration and the CIME. 
+The changes are required to ensure consistency between the model configuration and the CIME.
 
 .. warning::
 

--- a/docs/UsersGuide/source/inputs_outputs.rst
+++ b/docs/UsersGuide/source/inputs_outputs.rst
@@ -12,13 +12,13 @@ detailed documentation for each of the components are provided.
 Input files
 ===========
 
-The MR Weather App requires numerous input files. 
+The MR Weather App requires numerous input files.
 The input files data format can be
 `GRIB2 <https://www.nco.ncep.noaa.gov/pmb/docs/grib2/>`_,
-`NEMSIO <https://github.com/NOAA-EMC/NCEPLIBS-nemsio/wiki/Home-NEMSIO>`_, or 
-`netCDF <https://www.unidata.ucar.edu/software/netcdf/>`_, and the input files  
+`NEMSIO <https://github.com/NOAA-EMC/NCEPLIBS-nemsio/wiki/Home-NEMSIO>`_, or
+`netCDF <https://www.unidata.ucar.edu/software/netcdf/>`_, and the input files
 must be staged by
-the user. :term:`CIME` can 
+the user. :term:`CIME` can
 run the end-to-end system and write output files to disk.
 
 -----------
@@ -145,26 +145,33 @@ Initial condition formats and source
 
 The MR Weather App currently only supports the use of Global Forecast System
 (GFS) data as raw initial conditions (that is, MRF, AVN, ERA5 etc. are not supported).
-The GFS data can be provided in three formats: :term:`NEMSIO`, :term:`netCDF`, or :term:`GRIB2`. 
+The GFS data can be provided in three formats: :term:`NEMSIO`, :term:`netCDF`, or :term:`GRIB2`.
 
 - **NEMSIO**
 
   These files cover the entire globe down to a horizontal resolution of 13 km and
-  can be found at `<https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/>`_.  
-  
+  can be found at `<https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/>`_.
+  A small sample is also available at the FTP data repository `<https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.
+
 - **NetCDF**
 
   These files cover the entire globe down to a horizontal resolution of 13 km and
-  can be found at the FTP data repository `<https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.  
-     
+  can be found at the FTP data repository `<https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.
+
 - **GRIB2**
 
-  These files cover the entire globe and resolutions of 0.5 and 1.0 degree are supported. There are both current and historic sources of GRIB2 data available. At the time of this writing, files for dates 05/15/2020 12 UTC or more recent are considered current, while files for preceding dates are considered historical. However, the cutoff date may change in the future. Here are the locations:
+  These files cover the entire globe and resolutions of 0.5 and 1.0 degree are
+  supported. There are both current and historic sources of GRIB2 data available.
+  At the time of this writing, files for dates 05/15/2020 12 UTC or more recent
+  are considered current, while files for preceding dates are considered historical.
+  However, the cutoff date may change in the future. Here are the locations:
 
   - 0.5 deg current files are available at `<https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g4-anl-files/catalog.html>`_
   - 0.5 deg historical files are available at `<https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g4-anl-files-old/catalog.html>`_
   - 1.0 deg current files can be requested from `<https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g3-anl-files/catalog.html>`_
   - 1.0 deg historical files can be requested from `<https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g3-anl-files-old/catalog.html>`_
+
+  A small sample is also available at the FTP data repository `<https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.
 
 ------------------------------------
 Initial condition naming convention
@@ -175,13 +182,13 @@ The default naming convention for the initial condition files is described below
 - **NEMSIO**
 
   - Two-dimensional surface variables ``sfc.input.ic.nemsio``
-  - Three-dimensional atmosphere state ``atm.input.ic.nemsio`` 
+  - Three-dimensional atmosphere state ``atm.input.ic.nemsio``
 
 - **NetCDF**
 
   - Two-dimensional surface variables ``sfc.input.ic.nc``
-  - Three-dimensional atmosphere state ``atm.input.ic.nc`` 
- 
+  - Three-dimensional atmosphere state ``atm.input.ic.nc``
+
 - **GRIB2**
 
   - Surface variables and atmosphere state ``atm.input.ic.grb2``
@@ -261,7 +268,7 @@ The data should be placed in ``$DIN_LOC_IC``.
          ln -s gfs.t${hh}z.atmanl.nemsio atm.input.ic.nemsio
          ln -s gfs.t${hh}z.sfcanl.nemsio sfc.input.ic.nemsio
 
-     For downloading files in GRIB2 format with 0.5 degree grid spacing, the same code ``get.sh`` can be used except the wget command should be replaced with the following line: 
+     For downloading files in GRIB2 format with 0.5 degree grid spacing, the same code ``get.sh`` can be used except the wget command should be replaced with the following line:
 
      .. code-block:: console
 
@@ -270,7 +277,7 @@ The data should be placed in ``$DIN_LOC_IC``.
          #For historic files:
          wget -c https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g4-anl-files-old/$yyyymmdd/gfsanl_4_${yyyymmdd}_${hh}00_000.grb2
 
-     For downloading files in GRIB2 format with 1.0 degree grid spacing, the same code ``get.sh`` can be used except the wget command should be replaced with the following line: 
+     For downloading files in GRIB2 format with 1.0 degree grid spacing, the same code ``get.sh`` can be used except the wget command should be replaced with the following line:
 
 
      .. code-block:: console
@@ -280,7 +287,7 @@ The data should be placed in ``$DIN_LOC_IC``.
          #For historical files:
          wget -c https://www.ncei.noaa.gov/thredds/catalog/model-gfs-g3-anl-files-old/$yyyymmdd/gfsanl_3_${yyyymmdd}_${hh}00_000.grb2
 
-     After downloading the file, the user must link the new file to the name expected by the App. For example, 
+     After downloading the file, the user must link the new file to the name expected by the App. For example,
 
      .. code-block:: console
 

--- a/docs/UsersGuide/source/introduction.rst
+++ b/docs/UsersGuide/source/introduction.rst
@@ -38,7 +38,8 @@ v2 (:term:`GRIB2`) format (in 0.50, or 1.0 degree grid spacing),  the NOAA Envir
 Modeling System (:term:`NEMS`) Input/Output (:term:`NEMSIO`) format, or Network Common Data Form (:term:`NetCDF`).
 Initialization from dates starting on January 1, 2018 are supported. Dates
 before that may work, but are not guaranteed. GFS public archives can be
-accessed through  the `THREDDS Data Server at NCEI <https://www.ncei.noaa.gov/thredds/model/gfs.html>`_. A small sample of netCDF files can be found at `the EMC FTP site <https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.
+accessed through  the `THREDDS Data Server at NCEI <https://www.ncei.noaa.gov/thredds/model/gfs.html>`_.
+A small sample of files in all supported formats can be found at `the EMC FTP site <https://ftp.emc.ncep.noaa.gov/EIB/UFS/>`_.
 The initial conditions may be pre-staged on disk by the user or
 automatically downloaded by the workflow.
 
@@ -55,7 +56,7 @@ Supported grid configurations for this release are the global meshes with
 resolutions of C96 (~100 km), C192 (~50 km), C384 (~25 km), and C768 (~13 km),
 all with 64 vertical levels. The `NOAA Geophysical Fluid Dynamics Laboratory website <https://www.gfdl.noaa.gov/fv3>`_
 provides more information about FV3 and its grids. Additional information about the FV3 dynamical
-core is at `here <https://noaa-emc.github.io/FV3_Dycore_ufs-v1.0.0/html/index.html>`_.
+core is at `here <https://noaa-emc.github.io/FV3_Dycore_ufs-v1.1.0/html/index.html>`_.
 Interoperable atmospheric physics, along with the Noah land surface model, are
 supported through the use of the Common Community Physics Package (:term:`CCPP`;
 described `here <https://dtcenter.org/community-code/common-community-physics-package-ccpp>`_).
@@ -75,7 +76,7 @@ diurnal cycle.
 
 A scientific description of the CCPP parameterizations and suites can be found in the
 `CCPP Scientific Documentation <https://dtcenter.org/GMTB/v4.0/sci_doc>`_, and
-CCPP technical aspects are described in the `CCPP Technical Documentation <https://ccpp-techdoc.readthedocs.io/en/latest>`_.
+CCPP technical aspects are described in the `CCPP Technical Documentation <https://ccpp-techdoc.readthedocs.io/en/v4.1.0/>`_.
 The model namelists for the physics suites differ in ways that go beyond
 the physics to optimize various aspects of the model for use with each of the
 suites.
@@ -84,7 +85,7 @@ in this release, although the option is off by default in both of the
 supported physics suites. Three methods are supported for use separately or in
 combination: Stochastic Kinetic Energy Backscatter (SKEB), Stochastically
 Perturbed Physics Tendencies (SPPT), and Specific Humidity perturbations (SHUM).
-A `User’s Guide for the use of stochastic physics <https://stochastic-physics.readthedocs.io/en/ufs-v1.0.0>`_ is provided.
+A `User’s Guide for the use of stochastic physics <https://stochastic-physics.readthedocs.io/en/ufs-v1.1.0>`_ is provided.
 
 The UFS Weather Model ingests files produced by chgres_cube and outputs files
 in netCDF format on a Gaussian grid in the horizontal and model levels in the
@@ -97,7 +98,7 @@ The MR Weather App is distributed with a post-processing tools, the Unified
 Post Processor (UPP). The Unified Post Processor (UPP) converts the
 native netCDF output from the model to the :term:`GRIB2` format on standard isobaric
 coordinates in the vertical. The UPP can also be used to compute a variety of
-useful diagnostic fields, as described in the `UPP user's guide <https://upp.readthedocs.io/en/ufs-v1.0.0>`_.
+useful diagnostic fields, as described in the `UPP user's guide <https://upp.readthedocs.io/en/ufs-v1.1.0>`_.
 
 The UPP output can be used with visualization, plotting and verification
 packages, or for further downstream post-processing, e.g. statistical
@@ -154,7 +155,7 @@ it comes with two default configurations, or
 Component Sets (compsets). One compset is used to evoke the physics :term:`suite`
 used in the operational GFS v15, while the other is used to evoke the
 experimental GFS v16 physics. Based on the type of initial conditions, the
-workflow determines whether the to employ the variant with simple or more complex 
+workflow determines whether or not to employ the variant with simple or more complex
 SST. The workflow provides
 ways to choose the grid resolution, as well as to change namelist options,
 such as history file frequency. It also allows for configuration of other
@@ -190,7 +191,7 @@ the distributed documentation, summarized here for ease of use.
    | UFS Weather Model v1.1     | https://ufs-weather-model.readthedocs.io/en/ufs-v1.1.0                          |
    | User's Guide               |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
-   | FV3 Documentation          | https://noaa-emc.github.io/FV3_Dycore_ufs-v1.0.0/html/index.html                |
+   | FV3 Documentation          | https://noaa-emc.github.io/FV3_Dycore_ufs-v1.1.0/html/index.html                |
    +----------------------------+---------------------------------------------------------------------------------+
    | CCPP Scientific            | https://dtcenter.org/GMTB/v4.0/sci_doc                                          |
    | Documentation              |                                                                                 |
@@ -198,15 +199,15 @@ the distributed documentation, summarized here for ease of use.
    | CCPP Technical             | https://ccpp-techdoc.readthedocs.io/en/v4.0                                     |
    | Documentation              |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
-   | Stochastic Physics         | https://stochastic-physics.readthedocs.io/en/ufs-v1.0.0                         |
+   | Stochastic Physics         | https://stochastic-physics.readthedocs.io/en/ufs-v1.1.0                         |
    | User's Guide               |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
    | ESMF manual                | http://www.earthsystemmodeling.org/esmf_releases/public/ESMF_8_0_0/ESMF_refdoc  |
    +----------------------------+---------------------------------------------------------------------------------+
-   | Common Infrastructure for  | http://esmci.github.io/cime/versions/ufs_release_v1.0/html/index.html           |
+   | Common Infrastructure for  | http://esmci.github.io/cime/versions/ufs_release_v1.1/html/index.html           |
    | Modeling the Earth         |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
-   | Unified Post Processor     | https://upp.readthedocs.io/en/ufs-v1.0.0                                        |
+   | Unified Post Processor     | https://upp.readthedocs.io/en/ufs-v1.1.0                                        |
    +----------------------------+---------------------------------------------------------------------------------+
 
 The UFS community is encouraged to contribute to the UFS development effort.

--- a/docs/UsersGuide/source/introduction.rst
+++ b/docs/UsersGuide/source/introduction.rst
@@ -75,7 +75,7 @@ physical parameterization to forecast the temporal variation in SST due to the
 diurnal cycle.
 
 A scientific description of the CCPP parameterizations and suites can be found in the
-`CCPP Scientific Documentation <https://dtcenter.org/GMTB/v4.0/sci_doc>`_, and
+`CCPP Scientific Documentation <https://dtcenter.org/GMTB/v4.1/sci_doc>`_, and
 CCPP technical aspects are described in the `CCPP Technical Documentation <https://ccpp-techdoc.readthedocs.io/en/v4.1.0/>`_.
 The model namelists for the physics suites differ in ways that go beyond
 the physics to optimize various aspects of the model for use with each of the
@@ -193,10 +193,10 @@ the distributed documentation, summarized here for ease of use.
    +----------------------------+---------------------------------------------------------------------------------+
    | FV3 Documentation          | https://noaa-emc.github.io/FV3_Dycore_ufs-v1.1.0/html/index.html                |
    +----------------------------+---------------------------------------------------------------------------------+
-   | CCPP Scientific            | https://dtcenter.org/GMTB/v4.0/sci_doc                                          |
+   | CCPP Scientific            | https://dtcenter.org/GMTB/v4.1.0/sci_doc                                          |
    | Documentation              |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
-   | CCPP Technical             | https://ccpp-techdoc.readthedocs.io/en/v4.0                                     |
+   | CCPP Technical             | https://ccpp-techdoc.readthedocs.io/en/v4.1.0                                     |
    | Documentation              |                                                                                 |
    +----------------------------+---------------------------------------------------------------------------------+
    | Stochastic Physics         | https://stochastic-physics.readthedocs.io/en/ufs-v1.1.0                         |
@@ -241,8 +241,8 @@ building and running the MR Weather Application.
 
 If you are a new user, we recommend reading the first few sections of
 the `CIME`_ documentation which is written so that, as much as
-possible, individual sections stand on their own and the `CIME`_
-documentation guide can be scanned and sections read in a relatively
+possible, individual sections stand on their own. The `CIME`_
+documentation can be scanned and sections read in a relatively
 ad hoc order.
 
 .. code-block:: console

--- a/docs/UsersGuide/source/introduction.rst
+++ b/docs/UsersGuide/source/introduction.rst
@@ -75,7 +75,7 @@ physical parameterization to forecast the temporal variation in SST due to the
 diurnal cycle.
 
 A scientific description of the CCPP parameterizations and suites can be found in the
-`CCPP Scientific Documentation <https://dtcenter.org/GMTB/v4.1/sci_doc>`_, and
+`CCPP Scientific Documentation <https://dtcenter.org/GMTB/v4.1.0/sci_doc>`_, and
 CCPP technical aspects are described in the `CCPP Technical Documentation <https://ccpp-techdoc.readthedocs.io/en/v4.1.0/>`_.
 The model namelists for the physics suites differ in ways that go beyond
 the physics to optimize various aspects of the model for use with each of the

--- a/docs/UsersGuide/source/quickstart.rst
+++ b/docs/UsersGuide/source/quickstart.rst
@@ -28,13 +28,6 @@ This is the procedure for quickly setting up and running a case of MR Weather Ap
 * Build  a case: use ``case.build``
 * Run    a case: use ``case.submit``
 
-.. note::
-
-   Variables presented as ``$VAR`` in this guide typically refer to variables in XML files
-   that are created in your case directory. From within a case directory, you can determine the value of such a
-   variable with ``./xmlquery VAR``. In some instances, ``$VAR`` refers to a shell
-   variable or some other variable; we try to make these exceptions clear.
-
 .. _downloading:
 
 Downloading the MR Weather App code and scripts

--- a/docs/UsersGuide/source/repos_and_directories.rst
+++ b/docs/UsersGuide/source/repos_and_directories.rst
@@ -62,11 +62,11 @@ two layer repositories provide interfaces to allow CIME to properly build the uf
    wiki pages of those repositories: <https://github.com/NOAA-EMC/NCEPLIBS/wiki>` and
    <https://github.com/NOAA-EMC/NCEPLIBS-external/wiki>.
 
-The UPP code works in two ways with the MRW App. The code to create the UPP
+The UPP code works in two ways with the MR Weather App. The code to create the UPP
 executable is part of the NCEPLIBS, and the executable is already installed in
 preconfigued platforms. For the purposes of enabling customization of UPP fields,
 as described in the :ref:`Inputs and Outputs chapter <inputs_and_outputs>`,
-the UPP code is also included in the MRW App umbrella repository.
+the UPP code is also included in the MR Weather App umbrella repository.
 
 Directory Structure
 -------------------

--- a/docs/UsersGuide/source/repos_and_directories.rst
+++ b/docs/UsersGuide/source/repos_and_directories.rst
@@ -44,8 +44,8 @@ associated with this umbrella (see :numref:`Table %s <top_level_repos>`).
 The UFS MR Weather Model is itself an umbrella repository and contains a number of sub-repositories
 used by the model as documented `here
 <https://ufs-weather-model.readthedocs.io/en/ufs-v1.1.0/CodeOverview.html>`_.
-The CIME repository contains the workflow and build system for the prognostic model.  The last
-two repositories provide interfaces to allow CIME to properly build the ufs-weather-model and the NEMS driver.
+The CIME repository contains the workflow and build system for the prognostic model.  The
+two layer repositories provide interfaces to allow CIME to properly build the ufs-weather-model and the NEMS driver.
 
 .. note::
 
@@ -56,11 +56,17 @@ two repositories provide interfaces to allow CIME to properly build the ufs-weat
    `chgres_cube preprocessor repository <https://github.com/NOAA-EMC/UFS_UTILS>`_ and to `UPP
    <https://github.com/NOAA-EMC/EMC_post>`_.
 
-These external components are already built on the preconfigured platforms
-listed `here <https://github.com/ufs-community/ufs/wiki/Supported-Platforms-and-Compilers>`_.
-However, they must be cloned and built on other platforms according to the instructions provided in the
-wiki pages of those repositories: <https://github.com/NOAA-EMC/NCEPLIBS/wiki>` and
-<https://github.com/NOAA-EMC/NCEPLIBS-external/wiki>.
+   These external components are already built on the preconfigured platforms
+   listed `here <https://github.com/ufs-community/ufs/wiki/Supported-Platforms-and-Compilers>`_.
+   However, they must be cloned and built on other platforms according to the instructions provided in the
+   wiki pages of those repositories: <https://github.com/NOAA-EMC/NCEPLIBS/wiki>` and
+   <https://github.com/NOAA-EMC/NCEPLIBS-external/wiki>.
+
+The UPP code works in two ways with the MRW App. The code to create the UPP
+executable is part of the NCEPLIBS, and the executable is already installed in
+preconfigued platforms. For the purposes of enabling customization of UPP fields,
+as described in the :ref:`Inputs and Outputs chapter <inputs_and_outputs>`,
+the UPP code is also included in the MRW App umbrella repository.
 
 Directory Structure
 -------------------


### PR DESCRIPTION
Fixed links, explained why UPP is part of the code to be checked out with manage_externals, removed explanation of ``VAR`` that appeared twice, added further clarification on contents of FTP site, broke long lines into manageable sizes, removed white spaces, and improved answer to FAQ#1.

The HTML corresponding to this PR can be seen at https://ligia-mrw-ugs.readthedocs.io/en/userguide_update/index.html

Pending any changes suggested in the review process, this completes the App User's Guide for the v1.1.0 release.

