### PR TITLE
User guide update: FAQ for wall clock on Gaea, removal of unnecessary variable

### DIFF
--- a/docs/UsersGuide/source/faq.rst
+++ b/docs/UsersGuide/source/faq.rst
@@ -107,6 +107,12 @@ The following command will change the job queue to ``bigmem`` for ``chgres_cube`
     Without the ``--subgroup`` option, the ``xmlchange`` command changes the job wall clock time for all
     submitted jobs.
 
+What should the wall clock time be for a C768 24-hour forecast on Gaea?
+=======================================================================
+
+For this run you should set the ``JOB_WALLCLOCK_TIME`` to one hour. For instructions
+on how to do that, see the FAQ above.
+
 How can I change the project account that will be used to submit jobs?
 ======================================================================
 

--- a/docs/UsersGuide/source/quickstart.rst
+++ b/docs/UsersGuide/source/quickstart.rst
@@ -443,7 +443,6 @@ now are:
    .. code-block:: console
 
       ./xmlchange JOB_WALLCLOCK_TIME=00:30:00
-      ./xmlchange USER_REQUESTED_WALLTIME=00:30:00
 
 4. The default start date (2019-08-29, 00 UTC) can be also changed by following commands
 


### PR DESCRIPTION
Added FAQ for wall clock on Gaea. Removed mention of USER_REQUESTED WALLTIME.
Addresses: https://github.com/ufs-community/ufs-mrweather-app/issues/206
