### PR TITLE
sphinxcontrib-bibtex has been upgraded to 2.0.0 as of 12 Dec 2020.

### DIFF
--- a/docs/UsersGuide/source/conf.py
+++ b/docs/UsersGuide/source/conf.py
@@ -53,6 +53,8 @@ extensions = [
     'sphinx.ext.napoleon',
 ]
 
+bibtex_bibfiles = ['references.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This requires bibtex_bibfiles to be set in conf.py for ReadTheDocs to build
the documentation.

Both HTML and PDF builds succeeded.